### PR TITLE
moving flush tasks from optionaltasks queue

### DIFF
--- a/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/Memtable.java
+++ b/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/Memtable.java
@@ -70,7 +70,7 @@ public class Memtable
      * which is necessary for replay in case of a restart since CommitLog assumes that when onMF is
      * called, all data up to the given context has been persisted to SSTables.
      */
-    private static final ExecutorService flushWriter
+    public static final ExecutorService flushWriter
             = new JMXEnabledThreadPoolExecutor(DatabaseDescriptor.getFlushWriters(),
                                                StageManager.KEEPALIVE,
                                                TimeUnit.SECONDS,

--- a/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashBulkReplayer.java
+++ b/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashBulkReplayer.java
@@ -62,7 +62,7 @@ import com.ibm.research.capiblock.Chunk;
 public class FlashBulkReplayer {
 	private static int BULK_BLOCKS_TO_READ = 8000;// 32 MB pieces
 	static final Logger logger = LoggerFactory.getLogger(FlashBulkReplayer.class);
-	private static final int MAX_OUTSTANDING_REPLAY_COUNT = 1024 * 1024; // this
+	private static final int MAX_OUTSTANDING_REPLAY_COUNT = 1024; // this
 																			// is
 																			// 1024
 																			// by

--- a/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashCommitLog.java
+++ b/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashCommitLog.java
@@ -80,7 +80,6 @@ public class FlashCommitLog implements ICommitLog {
 				queue.add(new FlashWorker(chunkl, bufferSizeinMB));
 			}
 			if (DatabaseDescriptor.getConcurrentWriters() > flashThreads) {
-				// TODO
 				logger.error("Flashthreads should be at least number of concurrentWriters");
 				System.exit(1);
 			}
@@ -95,19 +94,16 @@ public class FlashCommitLog implements ICommitLog {
 								e.printStackTrace();
 							}
 							
-							logger.debug("--> Commitlog Monitor: Queue size:" + queue.size() + " Freelist Size="
+							logger.debug("--> Commitlog Monitor:Flash Worker Available Workers:" + queue.size() + " Freelist Size="
 									+ fsm.freelist.size());
 							logger.debug(
 									"--> Commitlog Monitor: Readers Waiting:" + Keyspace.switchLock.getReadLockCount()
-											+ " Writers : " + Keyspace.switchLock.isWriteLocked());
-							logger.debug("SWLock Q length: " + Keyspace.switchLock.getQueueLength());
-							logger.debug("Waiting for signal or switchlock acquire" + fsm.locked.get());
-							logger.debug("Allocate lock: "+ FlashSegmentManager.freelistState.isLocked() + "wQ length: "+FlashSegmentManager.freelistState.getQueueLength());
-							// logger.debug("SWLock Wait Q length:
-							logger.debug("Waiting for signal" + fsm.lockedonWait.get());
-							
-							// "+Keyspace.switchLock.getWaitQueueLength(Keyspace.CLogisEmpty));
-
+											+ " Is Write Locked:" + Keyspace.switchLock.isWriteLocked());
+							logger.debug("Commitlog Monitor:Switchlock queue length: " + Keyspace.switchLock.getQueueLength());
+							logger.debug("Commitlog Monitor:Waiting for signal or switchlock acquire" + fsm.locked.get());
+							logger.debug("Commitlog Monitor:FlashCommitlog internal lock: "+ FlashSegmentManager.freelistState.isLocked() + "Threads waiting to acquire lock: "+FlashSegmentManager.freelistState.getQueueLength());
+							logger.debug("Commitlog Monitor:Waiting for signal" + fsm.lockedonWait.get());
+							logger.debug("Commitlog Monitor:Flush Executor Active Tasks:"+FlashSegmentManager.flushexecutor.getActiveCount() + " Flush Executor Queue Size:" +  FlashSegmentManager.flushexecutor.getQueue().size());
 						}
 					}
 				}).start();
@@ -179,7 +175,7 @@ public class FlashCommitLog implements ICommitLog {
 					fsm.recycleSegment(segment);
 				} else {
 					logger.debug("Not safe to delete commit log segment {}; dirty is {} ",
-							segment.physical_block_address, "  dirty:", segment.dirtyString());
+							segment.physical_block_address, segment.dirtyString());
 				}
 			} else {
 				logger.debug("Not deleting active commitlog segment {} ", segment.physical_block_address);

--- a/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashSegment.java
+++ b/apache-cassandra-2.0.16-src-flashlog/src/java/org/apache/cassandra/db/commitlog/FlashSegment.java
@@ -60,7 +60,7 @@ public class FlashSegment {
 		physical_block_address = pb_id;
 	}
 
-	public synchronized boolean isActive() {
+	public boolean isActive() {
 		return !cfLastWrite.isEmpty();
 	}
 


### PR DESCRIPTION
- Created in-commitlog fixed size thread pool to consume flush requests when commitlog is out of space. 
- exposes memtable flushwriter queue to public
